### PR TITLE
Add cache rebuild

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,7 @@ Build instructions
 
 2.  Build the package:
 
-    dpkg-buildpackage
+    dpkg-buildpackage --no-sign
 
 Install instructions
 --------------------

--- a/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
+++ b/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
@@ -1,2 +1,2 @@
-pinentry-program /usr/bin/pinetry-curses
+pinentry-program /usr/bin/pinentry-curses
 allow-loopback-pinentry

--- a/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
+++ b/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
@@ -1,5 +1,6 @@
 pinentry-program /usr/bin/pinentry-curses
 allow-loopback-pinentry
+allow-preset-passphrase
 default-cache-ttl 1800
 max-cache-ttl 1800
 

--- a/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
+++ b/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
@@ -1,2 +1,5 @@
 pinentry-program /usr/bin/pinentry-curses
 allow-loopback-pinentry
+default-cache-ttl 1800
+max-cache-ttl 1800
+

--- a/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
+++ b/data/etc/ubuntu-secure-boot/keys/gpg-agent.conf
@@ -1,0 +1,2 @@
+pinentry-program /usr/bin/pinetry-curses
+allow-loopback-pinentry

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -242,6 +242,7 @@ then
         cat
         chain
         configfile
+        cryptodisk
         echo
         efifwsetup
         efinet
@@ -264,6 +265,7 @@ then
         lsefimmap
         lsefisystab
         lssal
+        luks
         memdisk
         minicmd
         normal

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Here we override the original grub-install with a custom version that does a
 # secure installation of GRUB.  For now, we don't support any of the original
@@ -69,6 +69,9 @@ Cleanup () {
     if [ -n "$PEMPRIVATEKEY" ] ; then
         rm -f "$PEMPRIVATEKEY"
     fi
+    if [ -n "$NULL_FILE" ]; then
+        rm -f "$NULL_FILE"
+    fi
 }
 
 # Obtain passphrase from user:
@@ -111,25 +114,33 @@ then
     PEMPRIVATEKEY="$(mktemp)"
     trap Cleanup EXIT INT TERM
 
-    # Extract public key:
-    KEYID=$(gpg -k --with-colons | grep "Ubuntu secure boot EFI key" \
-        | cut -d : -f 5)
+    export GPG_TTY=$(tty)
+
+    # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=838153
+    # KEYID is not in output. So instead, export and grep it
+    KEYID=$(gpg -a --export |gpg --list-packets --verbose | \
+      awk '/Ubuntu secure boot EFI key/ { printing=1 } /keyid/ { if (printing) { print $NF; printing=0} } {}')
+
     gpg --batch --yes --output "$GPGPUBLICKEY" --export "$KEYID"
 
     # Get passphrase:
+    NULL_FILE=$(mktemp)
     PASSPHRASEOK=0
+    gpg-connect-agent updatestartuptty /bye
     while [ "$PASSPHRASEOK" -eq 0 ] ; do
         GetPassphrase
+        rm -f "$NULL_FILE"
         # Test signing to make sure passphrase is ok
         echo "$PASSPHRASE" > "$PASSPHRASEFILE"
-        if ! : | gpg --batch -u "$KEYID" --passphrase-file "$PASSPHRASEFILE" \
-            -o /dev/null -as -
+        if ! : | gpg --pinentry-mode=loopback --batch -u "$KEYID" --passphrase-file "$PASSPHRASEFILE" \
+            -o "$NULL_FILE" -as -
         then
             RetryPassphrase
         else
             PASSPHRASEOK=1
         fi
     done
+    rm -f $"NULL_FILE"
 
     # We have to sign all GRUB files (e.g. modules) with gpg.  Currently,
     # grub-mkstandalone - while otherwise being the ideal tool to use
@@ -298,10 +309,16 @@ EOFPASSPHRASEEOF
     efibootmgr | grep -i "$BOOTLOADER_ID" | cut -c 5-8 | xargs -n 1 -r \
         efibootmgr --quiet --delete-bootnum --bootnum
     set -e
-    # Add new bootloader entry:
+    # Add new bootloader entry. nvme looks like /dev/nvme0n1p1
     DEVICE="$(df -T /boot/efi | sed -n 2p | awk '{ print $1}')"
-    DISK="$(echo "$DEVICE" | sed 's|[0-9]||g')"
-    PARTNUM="$(echo "$DEVICE" | sed 's|[^0-9]||g')"
+    if [[ $DEVICE =~ n[0-9]+p[0-9] ]]
+    then
+        DISK="$(echo "$DEVICE" | sed 's?p.*??g')"
+        PARTNUM="$(echo "$DEVICE" | sed 's?.*p??g')"
+    else
+        DISK="$(echo "$DEVICE" | sed 's|[0-9]||g')"
+        PARTNUM="$(echo "$DEVICE" | sed 's|[^0-9]||g')"
+    fi
     efibootmgr --quiet --create --disk "$DISK" --part "$PARTNUM" \
         --write-signature --label "$BOOTLOADER_ID" \
         --loader "\\EFI\\$BOOTLOADER_ID\\$EFI_FILENAME"

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -20,10 +20,20 @@
 # signature files, let GRUB go to a rescue prompt, and then turn off
 # check_signatures.
 
-set -e
 
 # Load debconf: used for prompting for passphrase.
 . /usr/share/debconf/confmodule
+
+KEYDIR=/etc/ubuntu-secure-boot/keys
+export GNUPGHOME="$KEYDIR"
+#tty=$(tty)
+#if [ $? -eq 0 ]
+#then
+#    export GPG_TTY=$(tty)
+#    gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
+#fi
+
+set -e
 
 runsbsign() {
     # On Ubuntu 16.04, sbsign crashes randomly; this appears to be a
@@ -52,21 +62,40 @@ EFI_FILENAME=securegrubx64.efi   # EFI image name
 BOOTLOADER_ID=ubuntu             # EFI directory on EFI partition
 FORMAT=x86_64-efi                # grub --format
 
-KEYDIR=/etc/ubuntu-secure-boot/keys
-export GNUPGHOME="$KEYDIR"
 
 # Temporary file cleanup
 Cleanup () {
-    if [ -n "$GPGPUBLICKEY" ] ; then
-        rm -f "$GPGPUBLICKEY"
-    fi
-    if [ -n "$GRUBSTAGE" ] ; then
-        rm -rf "$GRUBSTAGE"
-    fi
-    if [ -n "$PEMPRIVATEKEY" ] ; then
-        rm -f "$PEMPRIVATEKEY"
-    fi
+    [ -n "$GPGPUBLICKEY" ] && rm -f "$GPGPUBLICKEY" ]
+    [ -n "$GRUBSTAGE" ] && rm -rf "$GRUBSTAGE"
+    [ -n "$PEMPRIVATEKEY" ] && rm -f "$PEMPRIVATEKEY"
     [ -n "$NULL" ] && rm -f "$NULL"
+}
+
+GetPassphrase() {	
+    # Ask user for passphrase: note that we die if return code is 30,	
+    # indicating that the user won't be asked the question:	
+    db_settitle ubuntu-secure-boot/title	
+    db_reset ubuntu-secure-boot/passphrase	
+    db_fset ubuntu-secure-boot/passphrase seen false	
+    db_input critical ubuntu-secure-boot/passphrase	
+    db_go	
+    db_get ubuntu-secure-boot/passphrase	
+    PASSPHRASE="$RET"	
+    # Always reset the password so that it doesn't remain behind:	
+    db_reset ubuntu-secure-boot/passphrase	
+}	
+	
+# Ask if the user wants to retry entering passphrase:	
+RetryPassphrase() {	
+    db_settitle ubuntu-secure-boot/title	
+    db_reset ubuntu-secure-boot/retrypassphrase	
+    db_fset ubuntu-secure-boot/retrypassphrase seen false	
+    db_input critical ubuntu-secure-boot/retrypassphrase	
+    db_go	
+    db_get ubuntu-secure-boot/retrypassphrase	
+    if [ "$RET" != true ] ; then	
+        exit 1	
+    fi	
 }
 
 # Does key directory exist?
@@ -81,25 +110,54 @@ then
     NULL="$(mktemp)"
     trap Cleanup EXIT INT TERM
 
-    export GPG_TTY=$(tty)
 
     # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=838153
     # KEYID is not in output. So instead, export and grep it
     KEYID=$(gpg -a --export |gpg --list-packets --verbose | \
       awk '/Ubuntu secure boot EFI key/ { printing=1 } /keyid/ { if (printing) { print $NF; printing=0} } {}')
 
-    gpg --batch --yes --output "$GPGPUBLICKEY" --export "$KEYID"
+    gpg --yes --output "$GPGPUBLICKEY" --export "$KEYID"
 
-    gpg-connect-agent updatestartuptty /bye
-    
-    # Test signing to make sure passphrase is ok, also to
-    # fetch it into the gpg-agent cache
-    # We use a file for the output rather than /dev/null
-    # since it does a chmod 644 after its done!
-    until : | gpg --batch -u "$KEYID" -o "$NULL" -as -
+    set +e
+
+    PASSPHRASEOK=0
+    until [ $PASSPHRASEOK -eq 1 ]
     do
-	echo "Incorrect passphrase, retry"
+        : | gpg --pinentry-mode cancel --yes -u "$KEYID" -o "$NULL" -as - 2>/dev/null
+        if [ $? -eq 0 ]
+        then
+            PASSPHRASEOK=1
+        else
+            echo "get the passphrase"
+            GetPassphrase
+            echo "$PASSPHRASE" | gpg --batch --passphrase-fd 0 \
+                                      --pinentry-mode loopback --yes \
+                                      -u "$KEYID" -o "$NULL" -as /dev/null 2>/dev/null
+            if [ $? -eq 0 ]
+            then
+                PASSPHRASEOK=1
+            else
+                RetryPassphrase
+            fi
+        fi
     done
+    if [ $PASSPHRASEOK != 1 ]
+    then
+        echo "^C pressed, giving up"
+        exit 1
+    fi
+
+    set -e
+#    # Test signing to make sure passphrase is ok, also to
+#    # fetch it into the gpg-agent cache
+#    # We use a file for the output rather than /dev/null
+#    # since it does a chmod 644 after its done!
+#    until : | gpg --pinentry-mode ask --yes -u "$KEYID" -o "$NULL" -as -
+#    do
+#        rm -f "$NULL"
+#	echo "Incorrect passphrase, retry"
+#        sleep 1
+#    done
     rm -f "$NULL"
 
     # We have to sign all GRUB files (e.g. modules) with gpg.  Currently,
@@ -126,7 +184,7 @@ then
     # Sign GRUB files
     echo "Signing GRUB modules... (this will take a minute)"
     find "$GRUBSTAGE"/boot -type f -print0 | xargs -0 -n 1 \
-        gpg --yes --batch -u "$KEYID" --detach-sign
+        gpg -v --yes -u "$KEYID" --detach-sign
 
     # Make memdisk/tar image:
     echo "Creating memdisk..."
@@ -253,7 +311,11 @@ then
         $USED_MODULES
 
     # Save db.key OpenSSL key to an unencrypted file (remove passphrase):
-    openssl rsa -in "$KEYDIR/db.key" -out "$PEMPRIVATEKEY"
+    until echo "$PASSPHRASE" | openssl rsa -in "$KEYDIR/db.key" -out "$PEMPRIVATEKEY" -passin stdin
+    do
+        echo "Bad passphrase on ssl key"
+        sleep 1
+    done
 
     # Sign the EFI image into final output location.
     echo "Signing GRUB image..."

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -189,6 +189,8 @@ then
         verify
         gcry_rsa
         gcry_dsa
+        gcry_sha256
+        gcry_sha512
         "
     # The upstream Debian version of GRUB2 applies a special patch called
     # debian/patches/no_insmod_on_sb.patch:
@@ -282,7 +284,7 @@ then
     # If the user is running an older version of Ubuntu/GRUB2, they might not
     # have all the modules listed above.  Filter out the ones they don't have.
     WANTED_FILE=$(mktemp)
-    echo $GRUB_MODULES | tr ' ' '\0' | tr -d '\n' | sort -z > "$WANTED_FILE"
+    echo $GRUB_MODULES | tr ' ' '\0' | tr -d '\n' | sort -u -z > "$WANTED_FILE"
     ACTUAL_FILE=$(mktemp)
     find "$GRUBSTAGE/boot/grub" -type f -name \*.mod -printf '%f\0' | \
         sed -z 's/\.mod//g' | sort -z > "$ACTUAL_FILE"

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -63,43 +63,10 @@ Cleanup () {
     if [ -n "$GRUBSTAGE" ] ; then
         rm -rf "$GRUBSTAGE"
     fi
-    if [ -n "$PASSPHRASEFILE" ] ; then
-        rm -f "$PASSPHRASEFILE"
-    fi
     if [ -n "$PEMPRIVATEKEY" ] ; then
         rm -f "$PEMPRIVATEKEY"
     fi
-    if [ -n "$NULL_FILE" ]; then
-        rm -f "$NULL_FILE"
-    fi
-}
-
-# Obtain passphrase from user:
-GetPassphrase() {
-    # Ask user for passphrase: note that we die if return code is 30,
-    # indicating that the user won't be asked the question:
-    db_settitle ubuntu-secure-boot/title
-    db_reset ubuntu-secure-boot/passphrase
-    db_fset ubuntu-secure-boot/passphrase seen false
-    db_input critical ubuntu-secure-boot/passphrase
-    db_go
-    db_get ubuntu-secure-boot/passphrase
-    PASSPHRASE="$RET"
-    # Always reset the password so that it doesn't remain behind:
-    db_reset ubuntu-secure-boot/passphrase
-}
-
-# Ask if the user wants to retry entering passphrase:
-RetryPassphrase() {
-    db_settitle ubuntu-secure-boot/title
-    db_reset ubuntu-secure-boot/retrypassphrase
-    db_fset ubuntu-secure-boot/retrypassphrase seen false
-    db_input critical ubuntu-secure-boot/retrypassphrase
-    db_go
-    db_get ubuntu-secure-boot/retrypassphrase
-    if [ "$RET" != true ] ; then
-        exit 1
-    fi
+    [ -n "$NULL" ] && rm -f "$NULL"
 }
 
 # Does key directory exist?
@@ -110,8 +77,8 @@ then
     # Temporary files:
     GPGPUBLICKEY="$(mktemp)"
     GRUBSTAGE="$(mktemp -d)"
-    PASSPHRASEFILE="$(mktemp)"
     PEMPRIVATEKEY="$(mktemp)"
+    NULL="$(mktemp)"
     trap Cleanup EXIT INT TERM
 
     export GPG_TTY=$(tty)
@@ -123,24 +90,17 @@ then
 
     gpg --batch --yes --output "$GPGPUBLICKEY" --export "$KEYID"
 
-    # Get passphrase:
-    NULL_FILE=$(mktemp)
-    PASSPHRASEOK=0
     gpg-connect-agent updatestartuptty /bye
-    while [ "$PASSPHRASEOK" -eq 0 ] ; do
-        GetPassphrase
-        rm -f "$NULL_FILE"
-        # Test signing to make sure passphrase is ok
-        echo "$PASSPHRASE" > "$PASSPHRASEFILE"
-        if ! : | gpg --pinentry-mode=loopback --batch -u "$KEYID" --passphrase-file "$PASSPHRASEFILE" \
-            -o "$NULL_FILE" -as -
-        then
-            RetryPassphrase
-        else
-            PASSPHRASEOK=1
-        fi
+    
+    # Test signing to make sure passphrase is ok, also to
+    # fetch it into the gpg-agent cache
+    # We use a file for the output rather than /dev/null
+    # since it does a chmod 644 after its done!
+    until : | gpg --batch -u "$KEYID" -o "$NULL" -as -
+    do
+	echo "Incorrect passphrase, retry"
     done
-    rm -f "$NULL_FILE"
+    rm -f "$NULL"
 
     # We have to sign all GRUB files (e.g. modules) with gpg.  Currently,
     # grub-mkstandalone - while otherwise being the ideal tool to use
@@ -166,8 +126,7 @@ then
     # Sign GRUB files
     echo "Signing GRUB modules... (this will take a minute)"
     find "$GRUBSTAGE"/boot -type f -print0 | xargs -0 -n 1 \
-        gpg --batch -u "$KEYID" --detach-sign \
-        --passphrase-file "$PASSPHRASEFILE"
+        gpg --yes --batch -u "$KEYID" --detach-sign
 
     # Make memdisk/tar image:
     echo "Creating memdisk..."
@@ -294,10 +253,7 @@ then
         $USED_MODULES
 
     # Save db.key OpenSSL key to an unencrypted file (remove passphrase):
-    openssl rsa -in "$KEYDIR/db.key" -out "$PEMPRIVATEKEY" -passin stdin \
-        << EOFPASSPHRASEEOF
-$PASSPHRASE
-EOFPASSPHRASEEOF
+    openssl rsa -in "$KEYDIR/db.key" -out "$PEMPRIVATEKEY"
 
     # Sign the EFI image into final output location.
     echo "Signing GRUB image..."
@@ -359,7 +315,7 @@ EOFPASSPHRASEEOF
         # Now sign the final output with gpg:
         if [ -e "$SECURE_BOOT_KERNEL_PATH" ] ; then
             gpg --yes --batch -u "$KEYID" --detach-sign \
-                --passphrase-file "$PASSPHRASEFILE" "$SECURE_BOOT_KERNEL_PATH"
+                "$SECURE_BOOT_KERNEL_PATH"
         fi
     elif [ "$SECURE_BOOT_KERNEL_ACTION" = postrm -a \
         "$SECURE_BOOT_KERNEL_HOOK" = 1 ]
@@ -394,8 +350,7 @@ EOFPASSPHRASEEOF
                 ;;
             esac
             # Sign final output with gpg:
-            gpg --yes --batch -u "$KEYID" --detach-sign \
-                --passphrase-file "$PASSPHRASEFILE" "$file"
+            gpg --yes --batch -u "$KEYID" --detach-sign "$file"
         done
     fi
 

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -140,7 +140,7 @@ then
             PASSPHRASEOK=1
         fi
     done
-    rm -f $"NULL_FILE"
+    rm -f "$NULL_FILE"
 
     # We have to sign all GRUB files (e.g. modules) with gpg.  Currently,
     # grub-mkstandalone - while otherwise being the ideal tool to use

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -344,9 +344,12 @@ EOFPASSPHRASEEOF
         # (see comments in update-grub).
         echo "Signing kernel or initrd at $SECURE_BOOT_KERNEL_PATH"
         if [ -n "$SECURE_BOOT_SIGNED_SOURCE" ] ; then
-            # Check source signature
-            gpg --verify "${SECURE_BOOT_SIGNED_SOURCE}.sig" \
-                "$SECURE_BOOT_SIGNED_SOURCE"
+            if [ -f "${SECURE_BOOT_SIGNED_SOURCE}.sig" ]
+            then
+                # Check source signature
+                gpg --verify "${SECURE_BOOT_SIGNED_SOURCE}.sig" \
+                    "$SECURE_BOOT_SIGNED_SOURCE"
+            fi
 
             # Copy and sign it to destination with sbsign:
             runsbsign --key "$PEMPRIVATEKEY" --cert "$KEYDIR/db.crt" \

--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -98,6 +98,47 @@ RetryPassphrase() {
     fi	
 }
 
+# Cache: if the result will be the same return 0, else 1
+# this prevents rebuilding grub modules many times (once
+# per kernel installed)
+CheckCache() {
+    ## is /etc/ubuntu-secure-boot/grub.cfg unchanged?
+    ## is GPGPUBLICKEY unchanged?
+    if [ ! -d /etc/ubuntu-secure-boot/cache ]
+    then
+        echo "grub-install cache: first run, rebuild"
+        mkdir -p /etc/ubuntu-secure-boot/cache
+        return 1
+    fi
+    if [ ! -f /etc/ubuntu-secure-boot/cache/grub.cfg ]
+    then
+        echo "grub-install cache: no previous grub.cfg, rebuild"
+        return 1
+    fi
+    if [ ! -f /etc/ubuntu-secure-boot/cache/grub.pubkey ]
+    then
+        echo "grub-install cache: no previous grub.pubkey, rebuild"
+        return 1
+    fi
+    cmp "$GPGPUBLICKEY" /etc/ubuntu-secure-boot/cache/grub.pubkey
+    if [ $? != 0 ]
+    then
+        echo "grub install cache: GPG key changed, rebuild"
+        return 1
+    fi
+    if [ -f /etc/ubuntu-secure-boot/grub.cfg ]
+    then
+        cmp /etc/ubuntu-secure-boot/grub.cfg /etc/ubuntu-secure-boot/cache/grub.cfg
+        if [ $? != 0 ]
+        then
+            echo "grub install cache: change in grub.cfg, rebuild"
+            return 1
+        fi
+    fi
+    echo "grub install cache: no changes found, do not rebuld"
+    return 0
+}
+
 # Does key directory exist?
 if [ -d "$KEYDIR" ] && gpg -K --with-colons | \
     grep -q "Ubuntu secure boot EFI key" && \
@@ -110,15 +151,19 @@ then
     NULL="$(mktemp)"
     trap Cleanup EXIT INT TERM
 
-
     # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=838153
     # KEYID is not in output. So instead, export and grep it
     KEYID=$(gpg -a --export |gpg --list-packets --verbose | \
       awk '/Ubuntu secure boot EFI key/ { printing=1 } /keyid/ { if (printing) { print $NF; printing=0} } {}')
 
     gpg --yes --output "$GPGPUBLICKEY" --export "$KEYID"
-
     set +e
+
+    CheckCache "$GPGPUBLICKEY"
+    if [ $? -eq 0 ]
+    then
+        exit 0
+    fi
 
     PASSPHRASEOK=0
     until [ $PASSPHRASEOK -eq 1 ]
@@ -433,6 +478,11 @@ then
     rm -rf /boot/grub/grubenv
     rm -rf /boot/grub/unicode.pf2
     : > /boot/grub/grub.cfg
+
+    # Now update cache
+    mkdir -p /etc/ubuntu-secure-boot/cache
+    cp "$GPGPUBLICKEY" /etc/ubuntu-secure-boot/cache/grub.pubkey
+    cp /etc/ubuntu-secure-boot/grub.cfg /etc/ubuntu-secure-boot/cache/grub.cfg
 
     exit 0
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,8 @@ ubuntu-secure-boot (0.1.3) unstable; urgency=low
 
   * Add support for gpg2.x (Ubuntu 18.04)
 
- -- Don Bowman <db@donbowman.ca>  Wed Feb 21 17:52:07 -0500
-`
+ -- Don Bowman <db@donbowman.ca>  Wed, 21 Feb 2018 17:52:07 -0500
+
 ubuntu-secure-boot (0.1.2) unstable; urgency=low
 
   * Work around upstream no_insmod_on_sb.patch that prevents us from loading

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-secure-boot (0.1.4) unstable; urgency=low
+
+  * feat: cache to avoid rebuild of all grub modules
+
+ -- Don Bowman <db@donbowman.ca>  Mon, 23 Dec 2019 11:57:39 -0500
+
 ubuntu-secure-boot (0.1.3) unstable; urgency=low
 
   * Add support for gpg2.x (Ubuntu 18.04)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-secure-boot (0.1.3) unstable; urgency=low
+
+  * Add support for gpg2.x (Ubuntu 18.04)
+
+ -- Don Bowman <db@donbowman.ca>  Wed Feb 21 17:52:07 -0500
+`
 ubuntu-secure-boot (0.1.2) unstable; urgency=low
 
   * Work around upstream no_insmod_on_sb.patch that prevents us from loading

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Package: ubuntu-secure-boot
 Architecture: amd64
 # Currently only tested on very recent versions of GRUB/gnupg:
 Depends: ${misc:Depends}, grub-efi-amd64 (>= 2.02~beta2-29ubuntu0.3),
-    gnupg (>= 1.4.18), efibootmgr (>= 0.12), openssl (>= 1.0.2),
+    gnupg (>= 1.4.18), pinentry-curses (>= 1.0.0), efibootmgr (>= 0.12), openssl (>= 1.0.2),
     uuid-runtime (>= 2.26.2), efitools (>= 1.4.2), sbsigntool (>= 0.6),
     patch (>= 2.7.5)
 # shim should be removed; it is signed by Canonical/Microsoft

--- a/debian/postrm
+++ b/debian/postrm
@@ -38,7 +38,7 @@ fi
 case "$1" in
     purge)
         # Clean up files made by this package.
-        rm -rf /etc/ubuntu-secure-boot/keys
+        #rm -rf /etc/ubuntu-secure-boot/keys
         rm -f /etc/ubuntu-secure-boot/grub.cfg
         rm -f /etc/grub.d/01_grub_secure_boot_password
         # Avoid wiping original post*.distrib scripts if they were still there:


### PR DESCRIPTION
Instead of rebuilding all grub modules for all kernels (resulting in the same output), rebuild them once if the key changes or the grub.cfg changes.
